### PR TITLE
Fix C3 hot reloading

### DIFF
--- a/plugs/c3/future.c3
+++ b/plugs/c3/future.c3
@@ -13,7 +13,7 @@ fn any! FutureDone.poll(&self, any data) @dynamic {
 }
 
 macro Future done(value) {
-    return @tclone(FutureDone{@tclone(value)});
+    return @clone(FutureDone{@clone(value)});
 }
 
 struct FutureReject(Future) {
@@ -27,7 +27,7 @@ fn any! FutureReject.poll(&self, any data) @dynamic {
 fn Future reject(anyfault excuse) {
     FutureReject r = {};
     r.excuse = excuse;
-    return @tclone(r);
+    return @clone(r);
 }
 
 def FutureThenFunction = fn Future(any result);
@@ -53,7 +53,7 @@ fn any! FutureThen.poll(&self, any data) @dynamic {
 }
 
 macro Future Future.then(Future left, FutureThenFunction f) {
-    return @tclone(FutureThen {
+    return @clone(FutureThen {
         .left = left,
         .f = f
     });
@@ -86,7 +86,7 @@ fn any! FutureCatch.poll(&self, any data) @dynamic {
 // inline macro or something?), but since catch is a C3 keyword we decided to call
 // @catch. If it causes any problems in the future we should consider a different naming.
 macro Future Future.@catch(Future left, FutureCatchFunction f) {
-    return @tclone(FutureCatch {
+    return @clone(FutureCatch {
         .left = left,
         .f = f
     });

--- a/plugs/c3/plug.c3
+++ b/plugs/c3/plug.c3
@@ -1,5 +1,6 @@
 import std::io;
 import std::math;
+import std::collections::list;
 import raylib5::rl;
 import future;
 
@@ -36,7 +37,7 @@ fn any! Lerp.poll(&self, any env) @dynamic {
 }
 
 fn Future lerp(float *place, float a, float b, float duration) {
-    return @tclone(Lerp {
+    return @clone(Lerp {
         .place = place,
         .a = a,
         .b = b,
@@ -60,7 +61,7 @@ fn any! Parallel.poll(&urmom, any env) @dynamic {
 }
 
 fn Future parallel(Future[] futures) {
-    return @tclone(Parallel {
+    return @clone(Parallel {
         .futures = futures,
     });
 }
@@ -82,33 +83,88 @@ fn any! Seq.poll(&urmom, any env) @dynamic {
 }
 
 fn Future seq(Future[] futures) {
-    return @tclone(Seq {
+    return @clone(Seq {
         .futures = futures,
     });
+}
+
+struct Patcher {
+    List(<Future*>) lerp;
+    List(<Future*>) par;
+    List(<Future*>) seq;
+}
+
+fn void Patcher.add(&urmom, Future *f) {
+    switch(f.type) {
+        case Lerp.typeid:
+            urmom.lerp.push(f);
+        case Parallel.typeid:
+            urmom.par.push(f);
+        case Seq.typeid:
+            urmom.seq.push(f);
+        default:
+            unreachable("unexpected type");
+    }
+}
+
+macro @list_patch(list, $Type) {
+    for (usz i = 0; i < list.len(); i++) {
+        *list[i] = (Future) any_make(list[i].ptr, $Type.typeid);
+    }
+}
+
+fn void Patcher.patch(&urmom) {
+    io::printfn("Patching futures");
+    @list_patch(urmom.lerp, Lerp);
+    @list_patch(urmom.par, Parallel);
+    @list_patch(urmom.seq, Seq);
+}
+
+fn void Patcher.clear(&urmom) {
+    urmom.lerp.clear();
+    urmom.par.clear();
+    urmom.seq.clear();
 }
 
 struct State {
     float t1, t2;
     bool finished;
     Future anim;
+    Patcher patcher;
 }
 
 State *state = null;
 
 fn void reset_anim()
 {
-    // TODO: clean up allocator::temp() here
-    state.anim = parallel(@tclone(Future[*] {
-        // TODO: Tuck the whole @tclone(Future[*]{ ... }) under the future constructors
+    // TODO: clean up allocator::heap() here
+    // Leaky-leaky
+    state.anim = parallel(@clone(Future[*] {
+        // TODO: Tuck the whole @clone(Future[*]{ ... }) under the future constructors
         // See if variadic args can be applied here
-        seq(@tclone(Future[*] {
+        seq(@clone(Future[*] {
             lerp(&state.t1, 0, 1, CYCLE_DURATION),
             lerp(&state.t1, 1, 0, CYCLE_DURATION/4),
         })),
-        seq(@tclone(Future[*] {
+        seq(@clone(Future[*] {
             lerp(&state.t2, 0, 1, CYCLE_DURATION + CYCLE_DURATION/4),
         }))
     }));
+
+    state.patcher.clear();
+
+    // TODO: reflection to do this automatically or something
+    // Maybe Future.traverse(fn void FutureTraverseFn(void *env, Future *f))?
+
+    state.patcher.add(&state.anim);
+    Parallel *p = anycast(state.anim, Parallel)!!;
+    foreach(&s: p.futures) {
+        state.patcher.add(s);
+        Seq *s1 = anycast(*s, Seq)!!;
+        foreach(&l: s1.futures) {
+            state.patcher.add(l);
+        }
+    }
 }
 
 fn void plug_init() @export("plug_init")
@@ -125,6 +181,8 @@ fn void* plug_pre_reload() @export("plug_pre_reload")
 fn void plug_post_reload(void *old_state) @export("plug_post_reload")
 {
     state = old_state;
+
+    state.patcher.patch();
 }
 
 fn void orbit_circle(Env env, float t, float radius, float orbit, Color color)


### PR DESCRIPTION
**TLDR**: do not use `tclone` as it's freed on library unload; `interface` is `any`, `typeid` is vtable and can be easily overwritten with `any_make`. 

This will still break if you change data layout or add new (unhandled) types, so it *should* be on par with C. 

Here's an explanation of how I came up with that.

Let's try to see what's actually happening during the hot reload:
```console
...
ERROR: 'Out of bounds memory access.'
  in std.core.builtin.print_backtrace (/home/user/.local/lib/c3/std/core/builtin.c3:69) [./build/libc3.so]
  in std.core.builtin.sig_segmentation_fault (/home/user/.local/lib/c3/std/core/builtin.c3:715) [./build/libc3.so]
  in __sigaction (source unavailable) [/usr/lib/libc.so.6]
  in plug.Parallel.poll (/home/user/projects/c3-tests/panim/plugs/c3/plug.c3:53) [./build/libc3.so]
  in plug_update (/home/user/projects/c3-tests/panim/plugs/c3/plug.c3:142) [./build/libc3.so]
  in main (/home/user/projects/c3-tests/panim/./panim/panim.c:285) [./build/panim]
  in __libc_init_first (source unavailable) [/usr/lib/libc.so.6]
  in __libc_start_main (source unavailable) [/usr/lib/libc.so.6]
  in _start (source unavailable) [./build/panim]
Illegal instruction (core dumped)
```

But why? Let's fire up the GDB:
```console
$ gdb --args ./build/panim ./build/libc3.so
(gdb) r
...
Thread 1 "panim" received signal SIGSEGV, Segmentation fault.
0x00007ffff7a7cda1 in plug.Parallel.poll (urmom=0x555556ef3780, env=...) at plug.c3:53
53	    foreach (future: &urmom.futures) {
(gdb) p *urmom
$2 = {futures = {ptr = 0xaaaaaaaaaaaaaaaa, len = 12297829382473034410}}
```
Yeah, I can only agree with that. AAAAAAAAAAAAAAAA!

```
(gdb) b reload_libplug
(gdb) r
...
(gdb) p *((void **)state+2)
$1 = (void *) 0x555556ef3780
```
What's `*((void **)state+2)`? It's `state.anim`, the instance of `Future` interface (aka `any`)
Let's add watchpoint and see what updates it:
```console
(gdb) watch *0x555556ef3780@2
Hardware watchpoint 2: *0x555556ef3780@2
(gdb) c
Continuing.

Thread 1 "panim" hit Hardware watchpoint 2: *0x555556ef3780@2

Old value = {1458517840, 21845}
New value = {1458517930, 21845}
0x00007ffff7a78e26 in std.core.mem.allocator.TempAllocator.reset (self=0x555556ef3630, mark=0) at temp_allocator.c3:84
84						self.data[mark : cleaned] = 0xAA;
```

Mistery solved, I guess.

But this is not the end yet. If code layout changes even a little bit, we'll be greeted with
```
ERROR: 'No method 'poll' could be found on target'
  in std.core.builtin.default_panic (/home/user/.local/lib/c3/std/core/builtin.c3:99) [./build/libc3.so]
  in plug_update (/home/user/projects/c3-tests/panim/plugs/c3/plug.c3:283) [./build/libc3.so]
  in main (/home/user/projects/c3-tests/panim/./panim/panim.c:285) [./build/panim]
  in __libc_init_first (source unavailable) [/usr/lib/libc.so.6]
  in __libc_start_main (source unavailable) [/usr/lib/libc.so.6]
  in _start (source unavailable) [./build/panim]
Illegal instruction (core dumped)
```

That's interesting... So, apparently, dynamic dispatch failed.

Let's patch vtables then. Shouldn't be too hard, right? Padme.jpeg

Since interface is basically an `any` containing a pointer and a `typeid` (which is actually just a pointer to a global vtable), we can just
```zig
macro @patch(Future *f, $Type) {
    usz *x = (usz *) f;
    *x[1] = (usz) $Type.typeid;
}

fn void plug_post_reload(void *old_state) @export("plug_post_reload")
{
    state = old_state;

    @patch(&state.anim, Parallel);
    Parallel *p = anycast(state.anim, Parallel)!!;

    foreach(&s: p.futures) {
        @patch(s, Seq);
        Seq *s1 = anycast(*s, Seq)!!;
        foreach(&l: s1.futures) {
            @patch(l, Lerp);
            Lerp *l1 = anycast(*l, Lerp)!!;
            (void) l1;
        }
    }
}
```
Can your C++ or (safe) Rust do that? I don't fucking think so.

The actual implementation in this PR is a bit different so that this code would be closer to where `state.anim` is actually allocated.

Of course, there are some limitations, so having language support would've been much better. 
It's actually not that hard to implement by hooking into the allocator (so that it'll export hashmap of `typeid *` to `String` before unload and optionally import after reload).
I'll leave this as an exercise to the streamer.

**EDIT**: There is a `TrackingAllocator` which does almost that, but without the `typeid*` which needs to be tracked separately.